### PR TITLE
✨(backend) create backend docker image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 # -- Docker
-COMPOSE              = docker-compose
+DOCKER_UID           = $(shell id -u)
+DOCKER_GID           = $(shell id -g)
+DOCKER_USER          = $(DOCKER_UID):$(DOCKER_GID)
+COMPOSE              = DOCKER_USER=$(DOCKER_USER) docker-compose
 
 default: help
 
@@ -10,9 +13,19 @@ bootstrap: \
 .PHONY: bootstrap
 
 
-build: ## Build frontend image
-	@$(COMPOSE) build app
+build: ## Build docker images
+build: \
+	build-back \
+	build-front
 .PHONY: build
+
+build-back: ## Build backend image
+	@$(COMPOSE) build backend
+.PHONY: build-back
+
+build-front: ## Build frontend image
+	@$(COMPOSE) build frontend
+.PHONY: build-front
 
 run: ## Run all docker service
 	@$(COMPOSE) up -d

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,19 @@ version: '3.5'
 
 services:
   backend:
-    image: "moodlenet/moodlenet:stable" # use stable/production/master release of backend
+    build:
+      context: .
+      dockerfile: ./docker/images/backend/Dockerfile
+      target: moodlenet
+      args:
+        BACKEND_VERSION: "master"
+        DOCKER_USER: ${DOCKER_USER:-1000}
+    user: ${DOCKER_USER:-1000}
+    image: moodlenet:backend
     expose:
       - 4000
+    ports:
+      - "4000:4000"
     env_file:
       - env.d/db
       - env.d/moodlenet
@@ -13,7 +23,7 @@ services:
     volumes:
       - ./uploads:/var/www/uploads
 
-  app:
+  frontend:
     build:
       context: .
       dockerfile: ./docker/images/frontend/Dockerfile
@@ -37,6 +47,6 @@ services:
     image: sj26/mailcatcher:latest
     ports:
       - "1080:1080"
-  
+
 volumes:
    postgres_data:

--- a/docker/files/etc/nginx/conf.d/moodlenet.conf
+++ b/docker/files/etc/nginx/conf.d/moodlenet.conf
@@ -40,4 +40,8 @@ server {
   location /oauth {
     try_files $uri @proxy_to_backend;
   }
+
+  location /.well-known {
+    try_files $uri @proxy_to_backend;
+  }
 }

--- a/docker/files/usr/local/bin/entrypoint
+++ b/docker/files/usr/local/bin/entrypoint
@@ -1,0 +1,36 @@
+#!/bin/sh
+#
+# The container user (see USER in the Dockerfile) is an un-privileged user that
+# does not exists and is not created during the build phase (see Dockerfile).
+# Hence, we use this entrypoint to wrap commands that will be run in the
+# container to create an entry for this user in the /etc/passwd file.
+#
+# The following environment variables may be passed to the container to
+# customize running user account:
+#
+#   * USER_NAME: container user name (default: default)
+#   * HOME     : container user home directory (default: none)
+#
+# To pass environment variables, you can either use the -e option of the docker run command:
+#
+#     docker run --rm -e USER_NAME=foo -e HOME='/home/foo' moodlenet:backend moodle_net start
+#
+# or define new variables in an environment file to use with docker or docker-compose:
+#
+#     # env.d/production
+#     USER_NAME=foo
+#     HOME=/home/foo
+#
+#     docker run --rm --env-file env.d/production moodlenet:backend moodle_net start
+#
+
+echo "🐳(entrypoint) creating user running in the container..."
+if ! whoami > /dev/null 2>&1; then
+  if [ -w /etc/passwd ]; then
+    echo "${USER_NAME:-default}:x:$(id -u):$(id -g):${USER_NAME:-default} user:${HOME}:/sbin/nologin" >> /etc/passwd
+    cat /etc/passwd
+  fi
+fi
+
+echo "🐳(entrypoint) running your command: ${*}"
+exec "$@"

--- a/docker/images/backend/Dockerfile
+++ b/docker/images/backend/Dockerfile
@@ -1,0 +1,88 @@
+ARG ELIXIR_IMAGE_NAME=elixir
+ARG ELIXIR_IMAGE_TAG=1.10.2-slim
+
+
+# === DOWNLOAD ===
+FROM busybox as downloader
+
+WORKDIR /download
+
+# Moodlenet backend version that you want to build (git commit, tag or branch name)
+# related to the official repository : https://gitlab.com/moodlenet/backend/
+ARG BACKEND_VERSION=master
+
+RUN wget "https://gitlab.com/moodlenet/backend/-/archive/${BACKEND_VERSION}/backend-${BACKEND_VERSION}.tar.gz" && \
+    tar xzf "backend-${BACKEND_VERSION}.tar.gz" && \
+    rm "backend-${BACKEND_VERSION}.tar.gz" && \
+    mv "backend-${BACKEND_VERSION}" backend
+
+# === BUILD ===
+FROM ${ELIXIR_IMAGE_NAME}:${ELIXIR_IMAGE_TAG} as builder
+
+# The name of your application/release (required)
+ARG APP_NAME
+ARG APP_VSN
+ARG APP_BUILD
+
+WORKDIR /app
+
+ENV HOME=/app/
+ENV TERM=xterm
+ENV MIX_ENV=prod
+
+# dependencies for comeonin
+RUN apt-get update && \
+    apt-get install -y build-essential cmake curl git rustc cargo && \
+    rm -rf /var/lib/apt/lists/*
+
+# Cache elixir deps
+COPY --from=downloader /download/backend/mix.exs .
+COPY --from=downloader /download/backend/mix.lock .
+RUN mix do local.hex --force, local.rebar --force, deps.get, deps.compile
+
+COPY --from=downloader /download/backend .
+RUN mix release
+
+# === PRODUCTION ===
+FROM debian:buster as moodlenet
+
+ENV LANG=en_US.UTF-8
+
+RUN apt-get update && \
+    apt-get install -y ca-certificates libssl-dev locales tzdata && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN echo "$LANG UTF-8" >> /etc/locale.gen && \
+    locale-gen && \
+    update-locale LANG="$LANG"
+
+# The name of your application/release (required)
+ARG APP_NAME=Moodlenet-${BACKEND_VERSION}
+ENV APP_NAME=${APP_NAME}
+
+WORKDIR /app
+
+# install app
+COPY --from=builder /app/_build/prod/rel/moodle_net /app
+COPY ./docker/files/usr/local/bin/entrypoint /usr/local/bin/entrypoint
+
+# Un-privileged user running the application
+ARG DOCKER_USER
+
+# fix app permissions and ownership
+RUN chmod -R g=u /app/ && \
+    chown -R ${DOCKER_USER} /app/ && \
+    chgrp -R 0 /app
+
+# Give the "root" group the same permissions as the "root" user on /etc/passwd
+# to allow a user belonging to the root group to add new users; typically the
+# docker user (see entrypoint).
+RUN chmod g=u /etc/passwd
+
+USER ${DOCKER_USER}
+
+# We wrap commands run in this container by the following entrypoint that
+# creates a user on-the-fly with the container user ID (see USER) and root group
+# ID.
+ENTRYPOINT [ "/usr/local/bin/entrypoint" ]
+CMD /app/bin/moodle_net start


### PR DESCRIPTION
## Purpose

The official moodlnet backend docker image is based on the s6
process manager (via the s6-overlay project). It cannot be ran with a
non-privilegied user out of the box, due to the s6-overlay v1.22.1.0
that is used to build the image.

In addition to that, the image embeds a nginx server + the Erlang BEAM
application, supervised by s6. We want to have a container that run
_only_ the BEAM application.

And as a bonus, we prefer to use a debian based distribution instead
of alpine.

The goal of this docker image is to address these concerns.

## Proposal

- [x] Create a new moodlenet backend docker image
- [x] Update nginx configuration
