### PR TITLE
🐛(project) fix invalid test in bin/build

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -26,7 +26,7 @@ function build() {
     "upstream version ${version}${COLOR_RESET}"
 
     BACKEND_VERSION="${version}" DOCKER_USER="${docker_user}" docker-compose build backend
-    if [ "${tag}" -ne "moodlenet:backend" ]; then
+    if [ "${tag}" != "moodlenet:backend" ]; then
       docker tag moodlenet:backend "${tag}"
     fi
 


### PR DESCRIPTION
## Purpose

The CircleCI publishing workflow failed on main branch because of an incorrect test in the `bin/build` script.

See [here](https://app.circleci.com/pipelines/github/openfun/moodlenet-docker/7/workflows/3b275edc-9462-47c9-b4a7-c81260cf134c/jobs/24), the output of the _Build production image_ step has the following error : 
> bin/build: line 29: [: moodlenet-backend:1990b48afb8dafa8314c579354c0d0a4f4026104: integer expression expected


## Proposal

Fix the `bin/build` script.